### PR TITLE
fix: update Makefile to run test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 jabba
-coverage.html
+coverage.*
 release
 vendor
 kubesec

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ test-integration:
 	go test -v ./...
 
 test-coverage:
+	go vet ./...
+	(! gofmt -s -d . | grep '^')
 	go test -v ./... -coverprofile=./coverage.profile -cover
 	go tool cover -html=coverage.profile -o coverage.html
 	rm -f coverage.profile

--- a/Makefile
+++ b/Makefile
@@ -20,16 +20,20 @@ test-integration:
 	make .test
 
 .test:
-	go vet `go list ./... | grep -v /vendor/`
-	SRC=`find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./.tmp/*"` && \
-		gofmt -l -s $$SRC | read && gofmt -l -s -d $$SRC && exit 1 || true
-	go test -v `go list ./... | grep -v /vendor/` | grep -v "=== RUN"
+	go vet ./...
+	(! gofmt -s -d . | grep '^')
+	go test -v ./...
 
 test-coverage:
-	go list ./... | grep -v /vendor/ | xargs -L1 -I{} sh -c 'go test -coverprofile `basename {}`.coverprofile {}' && \
-	gover && \
-	go tool cover -html=gover.coverprofile -o coverage.html && \
-	rm -f *.coverprofile
+	go test -v ./... -coverprofile=./coverage.profile -cover
+	go tool cover -html=coverage.profile -o coverage.html
+	rm -f coverage.profile
+
+import-gpgkeys-for-test:
+	gpg2 --import .ci/jean-luc.picard.pubkey
+	gpg2 --allow-secret-key-import --import .ci/jean-luc.picard.seckey
+	gpg2 --keyserver pgp.mit.edu --recv-keys 160A7A9CF46221A56B06AD64461A804F2609FD89 72ECF46A56B4AD39C907BBB71646B01B86E50310 \
+	|| gpg2 --keyserver keyserver.ubuntu.com --recv-keys 160A7A9CF46221A56B06AD64461A804F2609FD89 72ECF46A56B4AD39C907BBB71646B01B86E50310
 
 build:
 	go build -ldflags "-X main.version=${VERSION}"

--- a/aws/kms/client.go
+++ b/aws/kms/client.go
@@ -1,10 +1,10 @@
 package kms
 
 import (
-	log "github.com/sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kms"
+	log "github.com/sirupsen/logrus"
 	"strings"
 )
 

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/shyiko/kubesec v0.0.0-20190816030733-7ce23ac7239c h1:au/8ClCUc9HTpuGePltbhd98DZcsqZEyG9DoFILieR4=
-github.com/shyiko/kubesec v0.0.0-20190816030733-7ce23ac7239c/go.mod h1:g2OYBaN/0UnIOQT5CYCcl1XsJdlSFd1HAr2j9Bn8gIA=
 github.com/sirupsen/logrus v1.0.3 h1:B5C/igNWoiULof20pKfY4VntcIPqKuwEmoLZrabbUrc=
 github.com/sirupsen/logrus v1.0.3/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/smartystreets/assertions v1.2.0 h1:42S6lae5dvLc7BrLu/0ugRtcFVjoJNMC/N3yZFZkDFs=

--- a/gpg/gpg.go
+++ b/gpg/gpg.go
@@ -50,7 +50,7 @@ type Key struct {
 }
 
 var pathToGPG string
-var keyring string // fixme: global state is bad but it's 2am, sorry
+var keyring string    // fixme: global state is bad but it's 2am, sorry
 var passphrase string // fixme: global state is bad but I just copied this ^^^
 
 func gpg() string {
@@ -74,7 +74,7 @@ func gpgCommand(command ...string) []string {
 	if passphrase != "" {
 		args = append(args, "--batch", "--pinentry=loopback", "--passphrase", passphrase)
 	}
-	return append(args, command...);
+	return append(args, command...)
 }
 
 // SetKeyring The keyring to source keys from
@@ -84,7 +84,7 @@ func SetKeyring(path string) {
 
 // SetPassphrase The passphrase to use for the signing key, disables pinentry
 func SetPassphrase(value string) {
-    passphrase = value
+	passphrase = value
 }
 
 // http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob_plain;f=doc/DETAILS
@@ -270,7 +270,7 @@ func pipeThroughGPG(content []byte, args ...string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	command := gpgCommand(args...)
 	if err := executeInShell(append(command, "-o", tmp.Name()+"E", tmp.Name())...); err != nil {
 		return nil, err


### PR DESCRIPTION
```sh
root@ef90d376f23b:/workdir# make import-gpgkeys-for-test
fatal: detected dubious ownership in repository at '/workdir'
To add an exception for this directory, call:

        git config --global --add safe.directory /workdir
gpg2 --import .ci/jean-luc.picard.pubkey
gpg: key 30BDA87E3E71C268: "Jean-Luc Picard <jean-luc.picard@uss-enterprise-d.starfleet>" not changed
gpg: Total number processed: 1
gpg:              unchanged: 1
gpg2 --allow-secret-key-import --import .ci/jean-luc.picard.seckey
gpg: key 30BDA87E3E71C268: "Jean-Luc Picard <jean-luc.picard@uss-enterprise-d.starfleet>" not changed
gpg: key 30BDA87E3E71C268: secret key imported
gpg: Total number processed: 1
gpg:              unchanged: 1
gpg:       secret keys read: 1
gpg:  secret keys unchanged: 1
gpg2 --keyserver pgp.mit.edu --recv-keys 160A7A9CF46221A56B06AD64461A804F2609FD89 72ECF46A56B4AD39C907BBB71646B01B86E50310 \
|| gpg2 --keyserver keyserver.ubuntu.com --recv-keys 160A7A9CF46221A56B06AD64461A804F2609FD89 72ECF46A56B4AD39C907BBB71646B01B86E50310
gpg: keyserver receive failed: No keyserver available
gpg: key 1646B01B86E50310: 7 duplicate signatures removed
gpg: key 1646B01B86E50310: "Yarn Packaging <yarn@dan.cx>" not changed
gpg: key 461A804F2609FD89: "Stanley Shyiko <stanley.shyiko@gmail.com>" not changed
gpg: Total number processed: 2
gpg:              unchanged: 2
root@ef90d376f23b:/workdir# make test 
fatal: detected dubious ownership in repository at '/workdir'
To add an exception for this directory, call:

        git config --global --add safe.directory /workdir
KUBESEC_TEST_AWS_KMS_KEY= KUBESEC_TEST_GCP_KMS_KEY= make .test
make[1]: Entering directory '/workdir'
fatal: detected dubious ownership in repository at '/workdir'
To add an exception for this directory, call:

        git config --global --add safe.directory /workdir
go vet ./...
(! gofmt -s -d . | grep '^')
go test -v ./...
?       kubesec [no test files]
=== RUN   TestEncrypt
    client_test.go:11: KUBESEC_TEST_AWS_KMS_KEY is not defined
--- SKIP: TestEncrypt (0.00s)
PASS
ok      kubesec/aws/kms (cached)
?       kubesec/cli     [no test files]
=== RUN   TestDecryptMalformed
--- PASS: TestDecryptMalformed (0.00s)
=== RUN   TestDecryptGivenEmptyData
--- PASS: TestDecryptGivenEmptyData (0.00s)
=== RUN   TestDecrypt
--- PASS: TestDecrypt (0.05s)
=== RUN   TestEncryptDecrypt
--- PASS: TestEncryptDecrypt (0.03s)
=== RUN   TestEncryptDecryptDifferentKey
--- PASS: TestEncryptDecryptDifferentKey (0.02s)
=== RUN   TestKeyChange
    edit_test.go:52: KUBESEC_TEST_AWS_KMS_KEY is not defined
--- SKIP: TestKeyChange (0.00s)
=== RUN   TestParseCommand
--- PASS: TestParseCommand (0.00s)
=== RUN   TestEditUnencrypted
--- PASS: TestEditUnencrypted (0.01s)
=== RUN   TestEditEncrypted
--- PASS: TestEditEncrypted (0.03s)
=== RUN   TestEncryptMalformed
--- PASS: TestEncryptMalformed (0.00s)
=== RUN   TestEncryptGivenEmptyData
--- PASS: TestEncryptGivenEmptyData (0.01s)
=== RUN   TestEncrypt
--- PASS: TestEncrypt (0.01s)
=== RUN   TestKeyRotation
--- PASS: TestKeyRotation (0.00s)
=== RUN   TestEncryptKeyAdd
--- PASS: TestEncryptKeyAdd (0.03s)
=== RUN   TestEncryptKeyRemove
--- PASS: TestEncryptKeyRemove (0.04s)
=== RUN   TestEncryptWithMissingKey
--- PASS: TestEncryptWithMissingKey (0.00s)
=== RUN   TestIntrospectUnencrypted
--- PASS: TestIntrospectUnencrypted (0.00s)
=== RUN   TestIntrospect
--- PASS: TestIntrospect (0.02s)
=== RUN   TestMergeWithEncryptedTarget
--- PASS: TestMergeWithEncryptedTarget (0.00s)
=== RUN   TestMergeWithUnencryptedSource
--- PASS: TestMergeWithUnencryptedSource (0.00s)
=== RUN   TestMerge
--- PASS: TestMerge (0.02s)
=== RUN   TestPatch
--- PASS: TestPatch (0.08s)
PASS
ok      kubesec/cmd     (cached)
=== RUN   TestEncrypt
--- PASS: TestEncrypt (0.00s)
=== RUN   TestEncryptEmpty
--- PASS: TestEncryptEmpty (0.00s)
=== RUN   TestDecrypt
--- PASS: TestDecrypt (0.00s)
=== RUN   TestDecryptEmpty
--- PASS: TestDecryptEmpty (0.00s)
PASS
ok      kubesec/crypto/aes      (cached)
=== RUN   TestEncrypt
    client_test.go:11: KUBESEC_TEST_GCP_KMS_KEY is not defined
--- SKIP: TestEncrypt (0.00s)
PASS
ok      kubesec/gcp/kms (cached)
=== RUN   TestParseKeys
--- PASS: TestParseKeys (0.00s)
=== RUN   TestParseSecretKeys
--- PASS: TestParseSecretKeys (0.00s)
PASS
ok      kubesec/gpg     (cached)
make[1]: Leaving directory '/workdir'
root@ef90d376f23b:/workdir# make test-coverage
fatal: detected dubious ownership in repository at '/workdir'
To add an exception for this directory, call:

        git config --global --add safe.directory /workdir
go vet ./...
(! gofmt -s -d . | grep '^')
go test -v ./... -coverprofile=./coverage.profile -cover
?       kubesec [no test files]
?       kubesec/cli     [no test files]
=== RUN   TestEncrypt
    client_test.go:11: KUBESEC_TEST_AWS_KMS_KEY is not defined
--- SKIP: TestEncrypt (0.00s)
PASS
        kubesec/aws/kms coverage: 0.0% of statements
ok      kubesec/aws/kms 0.005s  coverage: 0.0% of statements
=== RUN   TestDecryptMalformed
--- PASS: TestDecryptMalformed (0.00s)
=== RUN   TestDecryptGivenEmptyData
--- PASS: TestDecryptGivenEmptyData (0.00s)
=== RUN   TestDecrypt
--- PASS: TestDecrypt (0.04s)
=== RUN   TestEncryptDecrypt
--- PASS: TestEncryptDecrypt (0.02s)
=== RUN   TestEncryptDecryptDifferentKey
--- PASS: TestEncryptDecryptDifferentKey (0.01s)
=== RUN   TestKeyChange
    edit_test.go:52: KUBESEC_TEST_AWS_KMS_KEY is not defined
--- SKIP: TestKeyChange (0.00s)
=== RUN   TestParseCommand
--- PASS: TestParseCommand (0.00s)
=== RUN   TestEditUnencrypted
--- PASS: TestEditUnencrypted (0.02s)
=== RUN   TestEditEncrypted
--- PASS: TestEditEncrypted (0.03s)
=== RUN   TestEncryptMalformed
--- PASS: TestEncryptMalformed (0.00s)
=== RUN   TestEncryptGivenEmptyData
--- PASS: TestEncryptGivenEmptyData (0.01s)
=== RUN   TestEncrypt
--- PASS: TestEncrypt (0.01s)
=== RUN   TestKeyRotation
--- PASS: TestKeyRotation (0.00s)
=== RUN   TestEncryptKeyAdd
--- PASS: TestEncryptKeyAdd (0.03s)
=== RUN   TestEncryptKeyRemove
--- PASS: TestEncryptKeyRemove (0.03s)
=== RUN   TestEncryptWithMissingKey
--- PASS: TestEncryptWithMissingKey (0.00s)
=== RUN   TestIntrospectUnencrypted
--- PASS: TestIntrospectUnencrypted (0.00s)
=== RUN   TestIntrospect
--- PASS: TestIntrospect (0.02s)
=== RUN   TestMergeWithEncryptedTarget
--- PASS: TestMergeWithEncryptedTarget (0.00s)
=== RUN   TestMergeWithUnencryptedSource
--- PASS: TestMergeWithUnencryptedSource (0.00s)
=== RUN   TestMerge
--- PASS: TestMerge (0.02s)
=== RUN   TestPatch
--- PASS: TestPatch (0.08s)
PASS
        kubesec/cmd     coverage: 61.4% of statements
ok      kubesec/cmd     0.323s  coverage: 61.4% of statements
=== RUN   TestEncrypt
--- PASS: TestEncrypt (0.00s)
=== RUN   TestEncryptEmpty
--- PASS: TestEncryptEmpty (0.00s)
=== RUN   TestDecrypt
--- PASS: TestDecrypt (0.00s)
=== RUN   TestDecryptEmpty
--- PASS: TestDecryptEmpty (0.00s)
PASS
        kubesec/crypto/aes      coverage: 80.0% of statements
ok      kubesec/crypto/aes      0.008s  coverage: 80.0% of statements
=== RUN   TestEncrypt
    client_test.go:11: KUBESEC_TEST_GCP_KMS_KEY is not defined
--- SKIP: TestEncrypt (0.00s)
PASS
        kubesec/gcp/kms coverage: 0.0% of statements
ok      kubesec/gcp/kms 0.003s  coverage: 0.0% of statements
=== RUN   TestParseKeys
--- PASS: TestParseKeys (0.00s)
=== RUN   TestParseSecretKeys
--- PASS: TestParseSecretKeys (0.00s)
PASS
        kubesec/gpg     coverage: 23.0% of statements
ok      kubesec/gpg     0.003s  coverage: 23.0% of statements
go tool cover -html=coverage.profile -o coverage.html
rm -f coverage.profile
```